### PR TITLE
[ALS-9626] Add dataset and API privileges to database

### DIFF
--- a/Baseline/auth/V4__ADD_DATASET_AND_API_PRIVS.sql
+++ b/Baseline/auth/V4__ADD_DATASET_AND_API_PRIVS.sql
@@ -1,0 +1,35 @@
+INSERT INTO `privilege` (
+    uuid,
+    description,
+    name,
+    application_id,
+    queryScope,
+    queryTemplate
+) VALUES (
+    0xFD5513B5C5814867AADC3CD7E87C31D2,
+    'User who can manage saved datasets',
+    'NAMED_DATASET',
+    (SELECT uuid FROM application WHERE name = 'PICSURE'),
+    '[]',
+    NULL
+);
+
+INSERT INTO `privilege` (
+    uuid,
+    description,
+    name,
+    application_id,
+    queryScope,
+    queryTemplate
+) VALUES (
+    0x2CEC38E28895494B9FA8D1FE9737C387,
+    'User who can access the Ananlyze pages',
+    'API_ACCESS',
+    (SELECT uuid FROM application WHERE name = 'PICSURE'),
+    '[]',
+    NULL
+);
+
+INSERT INTO `role_privilege` (role_id, privilege_id) VALUES 
+(0x797FD002DC366B0D8420F998F885D0ED,0xFD5513B5C5814867AADC3CD7E87C31D2),
+(0x797FD002DC366B0D8420F998F885D0ED,0x2CEC38E28895494B9FA8D1FE9737C387);

--- a/GIC-Common-Area/auth/V24__ADD_DATASET_AND_API_PRIVS.sql
+++ b/GIC-Common-Area/auth/V24__ADD_DATASET_AND_API_PRIVS.sql
@@ -1,0 +1,35 @@
+INSERT INTO `privilege` (
+    uuid,
+    description,
+    name,
+    application_id,
+    queryScope,
+    queryTemplate
+) VALUES (
+    0xFD5513B5C5814867AADC3CD7E87C31D2,
+    'User who can manage saved datasets',
+    'NAMED_DATASET',
+    (SELECT uuid FROM application WHERE name = 'PICSURE'),
+    '[]',
+    NULL
+);
+
+INSERT INTO `privilege` (
+    uuid,
+    description,
+    name,
+    application_id,
+    queryScope,
+    queryTemplate
+) VALUES (
+    0x2CEC38E28895494B9FA8D1FE9737C387,
+    'User who can access the Ananlyze pages',
+    'API_ACCESS',
+    (SELECT uuid FROM application WHERE name = 'PICSURE'),
+    '[]',
+    NULL
+);
+
+INSERT INTO `role_privilege` (role_id, privilege_id) VALUES 
+(0x797FD002DC366B0D8420F998F885D0ED,0xFD5513B5C5814867AADC3CD7E87C31D2),
+(0x797FD002DC366B0D8420F998F885D0ED,0x2CEC38E28895494B9FA8D1FE9737C387);

--- a/GIC-Institution/auth/V17__ADD_DATASET_AND_API_PRIVS.sql
+++ b/GIC-Institution/auth/V17__ADD_DATASET_AND_API_PRIVS.sql
@@ -1,0 +1,35 @@
+INSERT INTO `privilege` (
+    uuid,
+    description,
+    name,
+    application_id,
+    queryScope,
+    queryTemplate
+) VALUES (
+    0xFD5513B5C5814867AADC3CD7E87C31D2,
+    'User who can manage saved datasets',
+    'NAMED_DATASET',
+    (SELECT uuid FROM application WHERE name = 'PICSURE'),
+    '[]',
+    NULL
+);
+
+INSERT INTO `privilege` (
+    uuid,
+    description,
+    name,
+    application_id,
+    queryScope,
+    queryTemplate
+) VALUES (
+    0x2CEC38E28895494B9FA8D1FE9737C387,
+    'User who can access the Ananlyze pages',
+    'API_ACCESS',
+    (SELECT uuid FROM application WHERE name = 'PICSURE'),
+    '[]',
+    NULL
+);
+
+INSERT INTO `role_privilege` (role_id, privilege_id) VALUES 
+(0x797FD002DC366B0D8420F998F885D0ED,0xFD5513B5C5814867AADC3CD7E87C31D2),
+(0x797FD002DC366B0D8420F998F885D0ED,0x2CEC38E28895494B9FA8D1FE9737C387);


### PR DESCRIPTION
The Frontend now shows the Analyze and Dataset pages based on these new privileges. This is how BDC worked previously. 
The privileges are added by default to the pic-sure user role.
Needed for this Frontend PR [#572](https://github.com/hms-dbmi/PIC-SURE-Frontend/pull/572)