### PR TITLE
WIP: PIC-SURE gateway rewrite — integration branch

### DIFF
--- a/Baseline/picsure/V8__DROP_RESOURCE_TABLE.sql
+++ b/Baseline/picsure/V8__DROP_RESOURCE_TABLE.sql
@@ -1,6 +1,6 @@
 use picsure;
 
--- Gateway rewrite (Phase 7): routing moved to the gateway's static per-service routes and the
+-- Gateway rewrite: routing moved to the gateway's static per-service routes and the
 -- resource registry endpoints were removed, so the resource table is unused. Drop the
 -- query -> resource foreign key (the resourceId column stays for historical rows) and then the
 -- table itself. Baseline flavor only for now -- the GIC flavors keep the table until the

--- a/Baseline/picsure/V8__DROP_RESOURCE_TABLE.sql
+++ b/Baseline/picsure/V8__DROP_RESOURCE_TABLE.sql
@@ -1,0 +1,20 @@
+use picsure;
+
+-- Gateway rewrite (Phase 7): routing moved to the gateway's static per-service routes and the
+-- resource registry endpoints were removed, so the resource table is unused. Drop the
+-- query -> resource foreign key (the resourceId column stays for historical rows) and then the
+-- table itself. Baseline flavor only for now -- the GIC flavors keep the table until the
+-- passthrough-service migration decision (Add Site to Passthrough Service writes to it).
+-- The FK name is looked up dynamically so this also works on older databases where the
+-- constraint was created by Hibernate with a different generated name.
+SET @fk := (SELECT CONSTRAINT_NAME FROM information_schema.REFERENTIAL_CONSTRAINTS
+            WHERE CONSTRAINT_SCHEMA = 'picsure'
+              AND TABLE_NAME = 'query'
+              AND REFERENCED_TABLE_NAME = 'resource'
+            LIMIT 1);
+SET @stmt := IF(@fk IS NULL, 'SELECT 1', CONCAT('ALTER TABLE `query` DROP FOREIGN KEY `', @fk, '`'));
+PREPARE drop_fk FROM @stmt;
+EXECUTE drop_fk;
+DEALLOCATE PREPARE drop_fk;
+
+DROP TABLE IF EXISTS `resource`;

--- a/GIC-Common-Area/auth/V25__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
+++ b/GIC-Common-Area/auth/V25__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
@@ -1,4 +1,4 @@
--- Phase 3: additive gateway clean-prefix rules; legacy /proxy rules retained until Phase 7 (WildFly decommission).
+-- Additive gateway clean-prefix rules; legacy /proxy rules retained until WildFly is decommissioned.
 --
 -- Note: this environment (GIC-Common-Area) only has a legacy access rule for the dictionary
 -- proxy path (V23__ADD_DICTIONARY_ACCESS_RULE.sql, linked to PIC_SURE_ANY_QUERY). There is no

--- a/GIC-Common-Area/auth/V25__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
+++ b/GIC-Common-Area/auth/V25__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
@@ -1,0 +1,24 @@
+-- Phase 3: additive gateway clean-prefix rules; legacy /proxy rules retained until Phase 7 (WildFly decommission).
+--
+-- Note: this environment (GIC-Common-Area) only has a legacy access rule for the dictionary
+-- proxy path (V23__ADD_DICTIONARY_ACCESS_RULE.sql, linked to PIC_SURE_ANY_QUERY). There is no
+-- legacy uploader access rule or DATA_ADMIN-style privilege wired up in this set, so there is
+-- nothing to mirror for an uploader clean-prefix rule here. Only the dictionary clean-prefix
+-- rule is added in this migration.
+
+SET @allDictCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
+-- Access rule for allowing requests to the dictionary via the gateway clean-prefix path
+INSERT
+INTO access_rule (
+    uuid, name, description, rule, type, value, checkMapKeyOnly, checkMapNode,
+    subAccessRuleParent_uuid, isGateAnyRelation, isEvaluateOnlyByGates
+)    VALUES (
+                @allDictCleanPrefixRequests, 'ALLOW_DICTIONARY_CLEAN_PREFIX', 'Permit requests to dictionary endpoints',
+                '$.[\'Target Service\']', 11, '^/dictionary(/.*)?$', 0x00, 0x00, NULL, 0x00, 0x00
+            );
+-- Add that access rule to the DATA_ADMIN privilege
+SET @uuidPriv = (SELECT uuid FROM privilege WHERE name = 'PIC_SURE_ANY_QUERY');
+INSERT
+INTO accessRule_privilege (privilege_id, accessRule_id)
+VALUES
+    (@uuidPriv, @allDictCleanPrefixRequests);

--- a/GIC-Common-Area/auth/V26__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
+++ b/GIC-Common-Area/auth/V26__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
@@ -1,4 +1,4 @@
--- Phase 3: additive gateway clean-prefix rule for visualization; legacy /proxy path kept until Phase 7.
+-- Additive gateway clean-prefix rule for visualization; legacy /proxy path kept until WildFly is decommissioned.
 
 SET @allVizCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
 -- Access rule for allowing requests to visualization via the gateway clean-prefix path

--- a/GIC-Common-Area/auth/V26__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
+++ b/GIC-Common-Area/auth/V26__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
@@ -1,0 +1,18 @@
+-- Phase 3: additive gateway clean-prefix rule for visualization; legacy /proxy path kept until Phase 7.
+
+SET @allVizCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
+-- Access rule for allowing requests to visualization via the gateway clean-prefix path
+INSERT
+INTO access_rule (
+    uuid, name, description, rule, type, value, checkMapKeyOnly, checkMapNode,
+    subAccessRuleParent_uuid, isGateAnyRelation, isEvaluateOnlyByGates
+)    VALUES (
+                @allVizCleanPrefixRequests, 'ALLOW_VISUALIZATION_CLEAN_PREFIX', 'Permit requests to visualization endpoints',
+                '$.[\'Target Service\']', 11, '^/visualization(/.*)?$', 0x00, 0x00, NULL, 0x00, 0x00
+            );
+-- Add that access rule to the PIC_SURE_ANY_QUERY privilege
+SET @uuidPriv = (SELECT uuid FROM privilege WHERE name = 'PIC_SURE_ANY_QUERY');
+INSERT
+INTO accessRule_privilege (privilege_id, accessRule_id)
+VALUES
+    (@uuidPriv, @allVizCleanPrefixRequests);

--- a/GIC-Institution/auth/V19__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
+++ b/GIC-Institution/auth/V19__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
@@ -1,0 +1,35 @@
+-- Phase 3: additive gateway clean-prefix rules; legacy /proxy rules retained until Phase 7 (WildFly decommission).
+
+SET @allDictCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
+-- Access rule for allowing requests to the dictionary via the gateway clean-prefix path
+INSERT
+INTO access_rule (
+    uuid, name, description, rule, type, value, checkMapKeyOnly, checkMapNode,
+    subAccessRuleParent_uuid, isGateAnyRelation, isEvaluateOnlyByGates
+)    VALUES (
+                @allDictCleanPrefixRequests, 'ALLOW_DICTIONARY_CLEAN_PREFIX', 'Permit requests to dictionary endpoints',
+                '$.[\'Target Service\']', 11, '^/dictionary(/.*)?$', 0x00, 0x00, NULL, 0x00, 0x00
+            );
+-- Add that access rule to the DATA_ADMIN privilege
+SET @uuidPriv = (SELECT uuid FROM privilege WHERE name = 'PIC_SURE_ANY_QUERY');
+INSERT
+INTO accessRule_privilege (privilege_id, accessRule_id)
+VALUES
+    (@uuidPriv, @allDictCleanPrefixRequests);
+
+SET @allowUploaderCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
+-- Access rule for allowing requests to the uploader via the gateway clean-prefix path
+INSERT
+    INTO access_rule (
+        uuid, name, description, rule, type, value, checkMapKeyOnly, checkMapNode,
+        subAccessRuleParent_uuid, isGateAnyRelation, isEvaluateOnlyByGates
+    )    VALUES (
+        @allowUploaderCleanPrefixRequests, 'ALLOW_UPLOADER_CLEAN_PREFIX', 'Permit requests to uploader endpoints',
+        '$.[\'Target Service\']', 11, '^/uploader(/.*)?$', 0x00, 0x00, NULL, 0x00, 0x00
+    );
+-- Add that access rule to the DATA_ADMIN privilege
+SET @uuidPriv = (SELECT uuid FROM privilege WHERE name = 'DATA_ADMIN');
+INSERT
+    INTO accessRule_privilege (privilege_id, accessRule_id)
+	VALUES
+	    (@uuidPriv, @allowUploaderCleanPrefixRequests);

--- a/GIC-Institution/auth/V19__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
+++ b/GIC-Institution/auth/V19__ADD_CLEAN_PREFIX_ACCESS_RULES.sql
@@ -1,4 +1,4 @@
--- Phase 3: additive gateway clean-prefix rules; legacy /proxy rules retained until Phase 7 (WildFly decommission).
+-- Additive gateway clean-prefix rules; legacy /proxy rules retained until WildFly is decommissioned.
 
 SET @allDictCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
 -- Access rule for allowing requests to the dictionary via the gateway clean-prefix path

--- a/GIC-Institution/auth/V20__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
+++ b/GIC-Institution/auth/V20__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
@@ -1,4 +1,4 @@
--- Phase 3: additive gateway clean-prefix rule for visualization; legacy /proxy path kept until Phase 7.
+-- Additive gateway clean-prefix rule for visualization; legacy /proxy path kept until WildFly is decommissioned.
 
 SET @allVizCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
 -- Access rule for allowing requests to visualization via the gateway clean-prefix path

--- a/GIC-Institution/auth/V20__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
+++ b/GIC-Institution/auth/V20__ADD_VISUALIZATION_CLEAN_PREFIX_ACCESS_RULE.sql
@@ -1,0 +1,18 @@
+-- Phase 3: additive gateway clean-prefix rule for visualization; legacy /proxy path kept until Phase 7.
+
+SET @allVizCleanPrefixRequests = unhex(REPLACE(UUID(),'-',''));
+-- Access rule for allowing requests to visualization via the gateway clean-prefix path
+INSERT
+INTO access_rule (
+    uuid, name, description, rule, type, value, checkMapKeyOnly, checkMapNode,
+    subAccessRuleParent_uuid, isGateAnyRelation, isEvaluateOnlyByGates
+)    VALUES (
+                @allVizCleanPrefixRequests, 'ALLOW_VISUALIZATION_CLEAN_PREFIX', 'Permit requests to visualization endpoints',
+                '$.[\'Target Service\']', 11, '^/visualization(/.*)?$', 0x00, 0x00, NULL, 0x00, 0x00
+            );
+-- Add that access rule to the PIC_SURE_ANY_QUERY privilege
+SET @uuidPriv = (SELECT uuid FROM privilege WHERE name = 'PIC_SURE_ANY_QUERY');
+INSERT
+INTO accessRule_privilege (privilege_id, accessRule_id)
+VALUES
+    (@uuidPriv, @allVizCleanPrefixRequests);


### PR DESCRIPTION
**Do not merge** until the full migration is ready to land on `main`.

This pull request introduces several SQL migration scripts to update access control and database structure as part of the gateway rewrite and clean-prefix migration. The main changes add new gateway access rules for dictionary, uploader, and visualization services in both GIC-Common-Area and GIC-Institution environments, and remove the obsolete `resource` table from the baseline schema.

**Access Rule Additions (Gateway Clean-Prefix Migration):**

* Added a clean-prefix access rule for dictionary endpoints to the GIC-Common-Area environment and linked it to the `PIC_SURE_ANY_QUERY` privilege.
* Added clean-prefix access rules for both dictionary and uploader endpoints in the GIC-Institution environment, associating them with the appropriate privileges (`PIC_SURE_ANY_QUERY` and `DATA_ADMIN`).
* Added clean-prefix access rules for visualization endpoints in both GIC-Common-Area and GIC-Institution environments, linked to the `PIC_SURE_ANY_QUERY` privilege. [[1]](diffhunk://#diff-44456328fa62613b2459398af42fa6585eb0570e81bdcb11acbb7f2dee0b2478R1-R18) [[2]](diffhunk://#diff-44456328fa62613b2459398af42fa6585eb0570e81bdcb11acbb7f2dee0b2478R1-R18)

**Database Schema Cleanup:**

* Dropped the obsolete `resource` table and its foreign key from the baseline `picsure` schema, as routing is now handled by the gateway and the table is no longer used. This cleanup is limited to the baseline flavor; GIC flavors retain the table for now.